### PR TITLE
[refactor] naver login 성공 시 return 값 변경

### DIFF
--- a/Server/lib/resolver-utils/NaverUserInfo.js
+++ b/Server/lib/resolver-utils/NaverUserInfo.js
@@ -9,7 +9,7 @@ const naverUserInfo = async (accessToken) => {
     })
 
     const result = await response.text();
-    console.log("유저 정보:", result);
+    
     if (response.status === 200) {
         return {status: response.status, userId: JSON.parse(result).response.id};
     }
@@ -25,7 +25,8 @@ const naverDuplicateCheck = async (context, id, nickname) => {
         if (targetUserNode.length > 0) {
             return {
                 nickname: result[result.length - 1].userName,
-                userIndex: targetUserNode.userIndex
+                userIndex: targetUserNode[0].userIndex,
+                newUser: false
             }
         } else {
             await context.prisma.user.create({
@@ -38,7 +39,8 @@ const naverDuplicateCheck = async (context, id, nickname) => {
             const currUserIndex = await makeUserNickname(context);
             return {
                 nickname: currUserIndex.nickName,
-                userIndex: currUserIndex.userIndex
+                userIndex: currUserIndex.userIndex,
+                newUser: true
             }
         }
     } catch (err) {

--- a/Server/lib/resolver/users.js
+++ b/Server/lib/resolver/users.js
@@ -9,7 +9,25 @@ const resolvers = {
             const response = await naverUserInfo(args.accessToken);
             if(response.status === 200) {
                 const isDuplicated = await naverDuplicateCheck(context, response.userId);
-                return createJwtToken(isDuplicated.userIndex);
+                const token = createJwtToken(isDuplicated.userIndex);
+                
+                if (isDuplicated.newUser) {
+                    return JSON.stringify({
+                        isSuccess: true,
+                        code: 200,
+                        message: "join success",
+                        JWT: token
+                    })
+                }
+                else {
+                    return JSON.stringify({
+                        isSuccess: true,
+                        code: 201,
+                        message: "login success",
+                        JWT: token
+                    })
+                }
+
             } else {
                 return JSON.stringify({
                     isSuccess: false,


### PR DESCRIPTION
# Update
* 네이버 로그인 성공 시 회원가입(새로 로그인)인지 로그인인지 클라이언트가 구분할 수 있도록 return 값 변경했습니다.

# Merge
* 머지대상: `feature/naver-duplicate-check` -> `develop`

- [x] 머지 대상을 정확하게 확인한 경우 체크해주세요!
