### PR TITLE
[fix] feedOpen 1인 값만 출력, JWT decode 과정 임시 삭제

### DIFF
--- a/Server/lib/resolver-utils/getFeeds.js
+++ b/Server/lib/resolver-utils/getFeeds.js
@@ -10,12 +10,15 @@ function tokenDecode(token){
 }
 
 const getAllLatestPost = async (token, context) => {
-    const decode = tokenDecode(token);
+    // const decode = tokenDecode(token);
 
-    if (decode === null) {
-        throw new Error('Invalid_Token')
-    }
-    const allLatestPost = await context.prisma.post.findMany({orderBy:[{uploadDate: 'desc'}]});
+    // if (decode === null) {
+    //     throw new Error('Invalid_Token')
+    // }
+    const allLatestPost = await context.prisma.post.findMany({
+        orderBy:[{uploadDate: 'desc'}],
+        where: {feedOpen: 1}
+    });
     for (const node of allLatestPost) {
         const userIndex = node.userIndex;
         const postIndex = node.postIndex;


### PR DESCRIPTION
# Update
** feedOpen 1인 값만 출력, JWT decode 과정 임시 삭제 **

# Merge
* 머지대상: `feature/main-feed` -> `develop`

- [x] 머지 대상을 정확하게 확인한 경우 체크해주세요!
