### PR TITLE
[feat] 리포팅 API 추가

### DIFF
--- a/Server/lib/resolver-utils/Post.js
+++ b/Server/lib/resolver-utils/Post.js
@@ -62,11 +62,37 @@ const addNewPost = async (token, args, context) => {
 
         return true
     } catch (err) {
-        throw err;
+        throw new Error(err);
+    }
+}
+
+const reporting = async (token, context) => {
+    let userIndex = -1;
+    const decode = jwtDecode(token.split(' ')[1])
+    if (decode === null) {
+        throw new Error('Invalid_Token')
+    } else {
+        userIndex = decode.ID;
+    }
+    try {
+        const reportingNodes = await context.prisma.post.findMany({
+            where: {userIndex: userIndex},
+            orderBy: [{uploadDate : 'desc'}],
+            take: 5
+        })
+
+        return 1;
+        // TODO: 실 사용 때는 아래 로직 사용 (현재는 반롤림 하지 않음)
+        // return reportingNodes.map(node => node.condition).reduce((acc, curr) => {
+        //     return acc + curr;
+        // }) / reportingNodes.length;
+    } catch (err) {
+        throw new Error(err);
     }
 }
 
 module.exports = {
     updatePostByLike,
-    addNewPost
+    addNewPost,
+    reporting
 }

--- a/Server/lib/resolver/feeds.js
+++ b/Server/lib/resolver/feeds.js
@@ -1,5 +1,5 @@
 const { getAllLatestPost, getSpecificExercise, getMyPost } = require('../resolver-utils/getFeeds');
-const { updatePostByLike, addNewPost } = require('../resolver-utils/Post');
+const { updatePostByLike, addNewPost, reporting } = require('../resolver-utils/Post');
 
 const resolvers = {
     Query: {
@@ -11,6 +11,9 @@ const resolvers = {
         },
         getMyPost: (parent, args, context) => {
             return getMyPost(context.req.headers['authorization'], args, context);
+        },
+        reporting: (parent, args, context) => {
+            return reporting(context.req.headers['authorization'], context);
         }
     },
     Mutation: {

--- a/Server/lib/typeDefs/Query.js
+++ b/Server/lib/typeDefs/Query.js
@@ -10,6 +10,7 @@ const typeDefs = gql`
             exercise: Int!
         ): PostData!
         getMyPost: PostData!
+        reporting: Int!
     }
 `
 


### PR DESCRIPTION
# Update
* 리포팅 API 입니다.
* 최근 피드 다섯개를 불러와서 컨디션의 평균을 내어 리턴합니다.
* 요청대로 리턴되는 로직은 주석처리 해놓았고 우선 1이 리턴이 됩니다.

# Merge
* 머지대상: `feature/return-post` -> `develop`

- [x] 머지 대상을 정확하게 확인한 경우 체크해주세요!
